### PR TITLE
Fix test failures with NumPy 1.11.0.

### DIFF
--- a/test_snuggs.py
+++ b/test_snuggs.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+import re
 
 import snuggs
 
@@ -151,8 +152,9 @@ def test_missing_closing_paren():
         result = snuggs.eval("(+ 1 2")
     assert excinfo.value.lineno == 1
     assert excinfo.value.offset == 7
-    assert (str(excinfo.value) == 'Expected ")"' or
-            str(excinfo.value) == 'Expected {Forward: ... | Forward: ...}')
+    exception_options = ['expected a function or operator',
+                         'Expected {Forward: ... | Forward: ...}']
+    assert str(excinfo.value) in exception_options
 
 
 def test_missing_func():
@@ -168,8 +170,9 @@ def test_missing_func2():
         result = snuggs.eval("(# 1 2)")
     assert excinfo.value.lineno == 1
     assert excinfo.value.offset == 2
-    assert (str(excinfo.value) == "expected a function or operator" or
-            str(excinfo.value) == "Expected {Forward: ... | Forward: ...}")
+    exception_options = ['expected a function or operator',
+                         'Expected {Forward: ... | Forward: ...}']
+    assert str(excinfo.value) in exception_options
 
 
 def test_undefined_var():
@@ -185,8 +188,9 @@ def test_bogus_higher_order_func():
         result = snuggs.eval("((bogus * 2) 2)")
     assert excinfo.value.lineno == 1
     assert excinfo.value.offset == 3
-    assert (str(excinfo.value) == "expected a function or operator" or
-            str(excinfo.value) == "Expected {Forward: ... | Forward: ...}")
+    exception_options = ['expected a function or operator',
+                         'Expected {Forward: ... | Forward: ...}']
+    assert str(excinfo.value) in exception_options
 
 
 def test_type_error():

--- a/test_snuggs.py
+++ b/test_snuggs.py
@@ -151,7 +151,8 @@ def test_missing_closing_paren():
         result = snuggs.eval("(+ 1 2")
     assert excinfo.value.lineno == 1
     assert excinfo.value.offset == 7
-    assert str(excinfo.value) == 'Expected ")"'
+    assert (str(excinfo.value) == 'Expected ")"' or
+            str(excinfo.value) == 'Expected {Forward: ... | Forward: ...}')
 
 
 def test_missing_func():
@@ -167,7 +168,8 @@ def test_missing_func2():
         result = snuggs.eval("(# 1 2)")
     assert excinfo.value.lineno == 1
     assert excinfo.value.offset == 2
-    assert str(excinfo.value) == "expected a function or operator"
+    assert (str(excinfo.value) == "expected a function or operator" or
+            str(excinfo.value) == "Expected {Forward: ... | Forward: ...}")
 
 
 def test_undefined_var():
@@ -183,7 +185,8 @@ def test_bogus_higher_order_func():
         result = snuggs.eval("((bogus * 2) 2)")
     assert excinfo.value.lineno == 1
     assert excinfo.value.offset == 3
-    assert str(excinfo.value) == "expected a function or operator"
+    assert (str(excinfo.value) == "expected a function or operator" or
+            str(excinfo.value) == "Expected {Forward: ... | Forward: ...}")
 
 
 def test_type_error():


### PR DESCRIPTION
As reported by Chris Lamb in [Debian Bug #824794](https://bugs.debian.org/824794), snuggs fails to build due to test failures:
```python
  ../../../test_snuggs.py ..........................F.F.F.
  
=================================== FAILURES ===================================
__________________________ test_missing_closing_paren __________________________
  
    def test_missing_closing_paren():
        with pytest.raises(SyntaxError) as excinfo:
            result = snuggs.eval("(+ 1 2")
        assert excinfo.value.lineno == 1
        assert excinfo.value.offset == 7
>       assert str(excinfo.value) == 'Expected ")"'
E       assert 'Expected {Fo...Forward: ...}' == 'Expected ")"'
E         - Expected {Forward: ... | Forward: ...}
E         + Expected ")"

../../../test_snuggs.py:154: AssertionError
______________________________ test_missing_func2 ______________________________

    def test_missing_func2():
        with pytest.raises(SyntaxError) as excinfo:
            result = snuggs.eval("(# 1 2)")
        assert excinfo.value.lineno == 1
        assert excinfo.value.offset == 2
>       assert str(excinfo.value) == "expected a function or operator"
E       assert 'Expected {Fo...Forward: ...}' == 'expected a fu...n or operator'
E         - Expected {Forward: ... | Forward: ...}
E         + expected a function or operator

../../../test_snuggs.py:170: AssertionError
_________________________ test_bogus_higher_order_func _________________________

    def test_bogus_higher_order_func():
        with pytest.raises(SyntaxError) as excinfo:
            result = snuggs.eval("((bogus * 2) 2)")
        assert excinfo.value.lineno == 1
        assert excinfo.value.offset == 3
>       assert str(excinfo.value) == "expected a function or operator"
E       assert 'Expected {Fo...Forward: ...}' == 'expected a fu...n or operator'
E         - Expected {Forward: ... | Forward: ...}
E         + expected a function or operator

../../../test_snuggs.py:186: AssertionError
===================== 3 failed, 29 passed in 0.16 seconds ======================
```
NumPy was recently updated to 1.11.0 in Debian, which seems to be the cause of the changed exception.

This PR changes the tests to also accept the new exception raised with NumPy 1.11.0.