### PR TITLE
Allow dict to be passed to snuggs.eval to maintain order of inputs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,22 @@ Expressions can also refer by name to arrays in a local context.
     snuggs.eval("(+ (asarray 1 1) b)", b=np.array([2, 2]))
     # array([3, 3])
 
+This local context may be provided using keyword arguments (e.g.,
+``b=np.array([2, 2])``), or by passing a dictionary that stores
+the keys and associated array values. Passing a dictionary, specifically
+an ``OrderedDict``, is important when using a function or operator that
+references the order in which values have been provided. For example,
+the ``read`` function will lookup the `i-th` value passed:
+
+.. code-block:: python
+
+    ctx = OrderedDict((
+        ('a', np.array([5, 5])),
+        ('b', np.array([2, 2]))
+    ))
+    snuggs.eval("(- (read 1) (read 2))", ctx)
+    # array([3, 3])
+
 Functions and operators
 =======================
 

--- a/snuggs/__init__.py
+++ b/snuggs/__init__.py
@@ -1,7 +1,7 @@
 """
 Snuggs are s-expressions for Numpy.
 """
-
+from collections import OrderedDict
 import functools
 import itertools
 import operator
@@ -26,7 +26,7 @@ string_types = (str,) if sys.version_info[0] >= 3 else (basestring,)
 class Context(object):
 
     def __init__(self):
-        self._data = {}
+        self._data = OrderedDict()
 
     def add(self, name, val):
         self._data[name] = val
@@ -42,15 +42,15 @@ class Context(object):
             return s
 
     def clear(self):
-        self._data = {}
+        self._data = OrderedDict()
 
 _ctx = Context()
 
 
 class ctx(object):
 
-    def __init__(self, **kwds):
-        self.kwds = kwds
+    def __init__(self, kwd_dict=None, **kwds):
+        self.kwds = kwd_dict or kwds
 
     def __enter__(self):
         _ctx.clear()
@@ -205,6 +205,7 @@ def handleLine(line):
         raise err
 
 
-def eval(source, **kwds):
-    with ctx(**kwds):
+def eval(source, kwd_dict=None, **kwds):
+    kwd_dict = kwd_dict or kwds
+    with ctx(kwd_dict):
         return handleLine(source)

--- a/test_snuggs.py
+++ b/test_snuggs.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import numpy
 import pytest
 
@@ -40,8 +42,14 @@ def test_arr_var(ones):
 
 
 def test_arr_lookup(ones):
-    r = snuggs.eval('(read 1)', foo=ones)
+    kwargs = OrderedDict((('foo', ones),
+                          ('bar', 2.0 * ones),
+                          ('a', 3.0 * ones)))
+    r = snuggs.eval('(read 1)', kwargs)
     assert list(r.flatten()) == [1, 1, 1, 1]
+    # Passed via kwargs this should fail (see issue #9)
+    r = snuggs.eval('(read 1)', **kwargs)
+    assert list(r.flatten()) != [1, 1, 1, 1]
 
 
 def test_arr_lookup_2(ones):


### PR DESCRIPTION
PR attempting to address #9 by introducing a new usage for `snuggs.eval` that would allow the data to be passed while maintaining the order of the keys passed. With the change, users could ensure computations within `snuggs.eval` maintain order (important for the `Context.lookup` method) by passing an `OrderedDict` as an argument, rather than via `**kwds` which does not maintain order prior to Python 3.6. This new argument defaults to `None` so older code using the `**kwds` pattern would not be affected by the change. The `Context._data` attribute also changes from a `dict` to an `OrderedDict` so items added via the `add` method would retain order.

I tried to be sparse while updating the README and tests to reflect the changes. I'm open to suggestions for changing things or any feedback. For example, I can see how having two methods for running the evaluation could be counterintuitive. My thought was that this approach would maintain the old usage while allowing downstream (i.e., rasterio) to perform calculations that correctly remember the order of inputs.

This is part 1 of 2 PRs I would submit to address mapbox/rasterio#947 because I would update the usage of snuggs inside the `rio calc` program to adjust to the fix here.

Thanks for your consideration!