### PR TITLE
Allow common identifier names

### DIFF
--- a/snuggs/__init__.py
+++ b/snuggs/__init__.py
@@ -10,7 +10,7 @@ import sys
 from pyparsing import (
     alphanums, ZeroOrMore, nums, oneOf, Word, Literal, Combine, QuotedString,
     ParseException, Forward, Group, CaselessLiteral, Optional, alphas,
-    OneOrMore, ParseResults)
+    OneOrMore, ParseResults, pyparsing_common)
 
 import numpy
 
@@ -105,7 +105,7 @@ decimal = Literal('.')
 e = CaselessLiteral('E')
 sign = Literal('+') | Literal('-')
 number = Word(nums)
-name = Word(alphas)
+name = pyparsing_common.identifier
 nil = Literal('nil').setParseAction(lambda s, l, t: [None])
 
 def resolve_var(s, l, t):

--- a/test_snuggs.py
+++ b/test_snuggs.py
@@ -48,6 +48,10 @@ def test_arr_lookup(ones):
     r = snuggs.eval('(read 1)', kwargs)
     assert list(r.flatten()) == [1, 1, 1, 1]
 
+def test_arr_var_long(ones):
+    r = snuggs.eval('(+ FOO_BAR_42 0)', FOO_BAR_42=ones)
+    assert list(r.flatten()) == [1, 1, 1, 1]
+
 
 @pytest.mark.xfail(reason="Keyword argument order can't be relied on")
 def test_arr_lookup_kwarg_order(ones):


### PR DESCRIPTION
Changes the current implementation to allow proper identifier names as defined in `pyparsing_common`, particularly this allows for identifiers similar to other programming languages.

I also added a simple test covering this scenario.